### PR TITLE
Add missing dependency: meshio

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "gmsh",
     "h5py",
     "matplotlib",
+    "meshio",
     "mpi4py",
     "numpy",
     "petsc4py",
@@ -173,6 +174,7 @@ conda_deps =
     gmsh
     h5py
     matplotlib
+    meshio
     mpi4py
     numpy
     petsc4py


### PR DESCRIPTION
We forgot one!
[See here](https://github.com/UCL/dxss/actions/runs/6148154181/job/16681244569#step:6:229), for example.