### PR TITLE
Python version increment to speed up the docs build

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.10
+          python-version: "3.10"
           cache: "pip"
           cache-dependency-path: "pyproject.toml"
       - name: Install tox

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.10
           cache: "pip"
           cache-dependency-path: "pyproject.toml"
       - name: Install tox


### PR DESCRIPTION
One of our dependencies is slowing down the Python 3.9 _tests_. But 3.10 tests are reasonable, so I guess we ought to build the docs in Python 3.10 for speed. (Note that the first time it'll need to cache so I guess it'll be slow.)