### PR TITLE
Add the sphinx TODO extension.

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,6 +19,7 @@ extensions = [
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
     "sphinx.ext.intersphinx",
+    "sphinx.ext.todo",
     "sphinx_autodoc_typehints",
 ]
 


### PR DESCRIPTION
Whilst doing the `sudo` force pushes I accidentally broke the doc build build by [committing a `Todo:` in a docstring](https://github.com/UCL/dxss/commit/ef27a6e6bcbe286ca2c3586555ffa2f414005ec7#diff-751cc4c9bd02dbe5a928d6d495a3ca4ba595542f2117d81b15822abf50f32ebaR63) which gets automatically converted into a `.. todo:` directive in sphinx.

But we don't have the todo sphinx extension. 🤦 

So this PR adds that.