### PR TITLE
Add support for dolfinx v0.7

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,11 @@ jobs:
         dolfinx-version:
           - "0.6"
           - "0.7"
+        exclude:
+          - dolfinx-version: "0.6"
+            python-version: "3.11"
+          - dolfinx-version: "0.6"
+            python-version: "3.12"
     steps:
       - name: Checkout source
         uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,11 @@ jobs:
         python-version:
           - "3.9"
           - "3.10"
+          - "3.11"
+          - "3.12"
+        dolfinx-version:
+          - "0.6"
+          - "0.7"
     steps:
       - name: Checkout source
         uses: actions/checkout@v3
@@ -41,8 +46,8 @@ jobs:
         # Workaround to map x.y Python version to form test-xy
         # https://stackoverflow.com/a/67248310
         run: |
-          RAW_TOX_ENV="test-py${{ matrix.python-version }}"
-          TOX_ENV=$(echo $RAW_TOX_ENV | sed 's/\.//')
+          RAW_TOX_ENV="test-py${{ matrix.python-version }}-dolfinx${{ matrix.dolfinx-version }}"
+          TOX_ENV=$(echo $RAW_TOX_ENV | sed 's/\.//g')
           echo "tox_env=$TOX_ENV" >> "$GITHUB_ENV"
 
       - name: Test with tox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         python-version:
           - "3.9"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,6 +11,7 @@ on:
 
 jobs:
   tests:
+    name: Tests with Python ${{ matrix.python-version }} and dolfinx ${{ matrix.dolfinx-version }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,6 +155,10 @@ conda_deps =
     dolfinx06: fenics-dolfinx==0.6.*
     dolfinx07: fenics-dolfinx==0.7.*
     docs: fenics-dolfinx
+    # Install gmsh with conda to avoid error
+    #     libGLU.so.1: cannot open shared object file: No such file or directory
+    # when libGLU not installed natively on system
+    gmsh
 conda_channels =
     conda-forge
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,7 @@ python =
 conda_deps =
     dolfinx06: fenics-dolfinx==0.6
     dolfinx07: fenics-dolfinx==0.7
+    docs: fenics-dolfinx==0.7
 conda_channels =
     conda-forge
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,7 +157,7 @@ conda_deps =
 conda_channels =
     conda-forge
 
-[testenv:test-py{39,310,311,312}-dolfinx{06,07}]
+[testenv:test-py{39,310}-dolfinx{06,07},test-py{311,312}-dolfinx07]
 commands =
     pytest -s --cov --cov-report=xml
 deps =
@@ -176,7 +176,8 @@ deps =
 
 [tox]
 envlist =
-    test-py{39,310,311,312}-dolfinx{06,07}
+    test-py{39,310}-dolfinx{06,07}
+    test-py{311,312}-dolfinx07
 isolated_build = true
 requires = tox-conda
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,11 +15,13 @@ classifiers = [
     "Programming Language :: Python :: 3 :: Only",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Typing :: Typed",
 ]
 dependencies = [
     "dxh@git+https://github.com/UCL/dxh",
-    "fenics-dolfinx==0.6.0",
+    "fenics-dolfinx>=0.6",
     "fenics-ufl",
     "gmsh",
     "h5py",
@@ -27,6 +29,7 @@ dependencies = [
     "meshio",
     "mpi4py",
     "numpy",
+    "packaging",
     "petsc4py",
     "scipy",
     "sympy",
@@ -39,7 +42,7 @@ keywords = [
 ]
 name = "dxss"
 readme = "README.md"
-requires-python = ">=3.9,<3.11"
+requires-python = ">=3.9"
 license.file = "LICENSE.md"
 
 [project.optional-dependencies]
@@ -142,27 +145,19 @@ overrides."tool.coverage.paths.source".inline_arrays = false
 legacy_tox_ini = """
 [gh-actions]
 python =
-    3.9: test-py39
-    3.10: test-py310
+    3.9: py39
+    3.10: py310
+    3.11: py311
+    3.12: py312
 
 [testenv]
 conda_deps =
-    fenics-dolfinx==0.6.0
-    fenics-ufl
-    gmsh
-    h5py
-    matplotlib
-    meshio
-    mpi4py
-    numpy
-    petsc4py
-    pypardiso
-    scipy
-    sympy
+    dolfinx06: fenics-dolfinx==0.6
+    dolfinx07: fenics-dolfinx==0.7
 conda_channels =
     conda-forge
 
-[testenv:test-py{39,310}]
+[testenv:test-py{39,310,311,312}-dolfinx{06,07}]
 commands =
     pytest -s --cov --cov-report=xml
 deps =
@@ -181,8 +176,7 @@ deps =
 
 [tox]
 envlist =
-    test-py39
-    test-py310
+    test-py{39,310,311,312}-dolfinx{06,07}
 isolated_build = true
 requires = tox-conda
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,13 +152,13 @@ python =
 
 [testenv]
 conda_deps =
-    dolfinx06: fenics-dolfinx==0.6
-    dolfinx07: fenics-dolfinx==0.7
-    docs: fenics-dolfinx==0.7
+    dolfinx06: fenics-dolfinx==0.6.*
+    dolfinx07: fenics-dolfinx==0.7.*
+    docs: fenics-dolfinx
 conda_channels =
     conda-forge
 
-[testenv:test-py{39,310}-dolfinx{06,07},test-py{311,312}-dolfinx07]
+[testenv:test-py{39,310,311,312}-dolfinx{06,07}]
 commands =
     pytest -s --cov --cov-report=xml
 deps =

--- a/src/dxss/meshes.py
+++ b/src/dxss/meshes.py
@@ -1,3 +1,5 @@
+from importlib.metadata import version
+
 import gmsh
 import numpy as np
 from dolfinx.cpp.io import perm_gmsh
@@ -11,6 +13,7 @@ from dolfinx.mesh import (
     refine,
 )
 from mpi4py import MPI
+from packaging.version import Version
 
 GM = GhostMode.shared_facet
 eta = 0.6
@@ -850,7 +853,14 @@ def get_mesh_data_all_around(n_ref, init_h_scale=1.0):  # noqa: PLR0915
     for _i in range(n_ref):
         mesh.topology.create_entities(1)
         cells = locate_entities(mesh, mesh.topology.dim, refine_all)
-        edges = compute_incident_entities(mesh, cells, 2, 1)
+        # Call signature for compute_incident_entities changed to accept mesh topology
+        # rather than mesh in dolfinx v0.7 so set relevant argument accordingly based on
+        # installed version
+        if Version(version("fenics-dolfinx")) < Version("0.7"):
+            mesh_or_topology = mesh
+        else:
+            mesh_or_topology = mesh.topology
+        edges = compute_incident_entities(mesh_or_topology, cells, 2, 1)
         mesh = refine(mesh, edges, redistribute=True)
         mesh_hierarchy.append(mesh)
     return mesh_hierarchy


### PR DESCRIPTION
Fixes #37 

Looks like there was only one breaking change in v0.6 &rightarrow; v0.7 of `dolfinx` that effects us (change of call signature of `dolfinx.mesh.compute_incident_entities` to accept a mesh topology as first argument rather than mesh object itself in [this commit](https://github.com/FEniCS/dolfinx/commit/03907173d76156246eecdde610dffd209e8a5e3e)) so for now I've kept things backwards compatible with v0.6 by just changing how we call conditionally based on the installed version (with the call only being in one place). To compare versions I'm using `importlib.metadata.version` to extract the package version (which should work irrespective of how the package is installed and whether a `__version__` attribute is defined on the top-level module) and `packaging.version.Version` class to compare versions according to PEP440 (which is where the extra `packaging` dependency comes from).

Currently we are blocked from installing in Python 3.11+ by the `python_requires` on `dxh` (UCL/dxh#17) so the tests on those Python versions I think will fail till we resolve there.

To avoid the duplication of the dependencies in the `legacy_tox_ini` declaration in `pyproject.toml` I also switched to only installing `fenics-dolfinx` with `conda` here with the rest installed with `pip` (and so picked up from `project.dependencies` field).