### PR TITLE
Refactor `dxss.gmres` module and add tests

### DIFF
--- a/src/dxss/solve_1d.py
+++ b/src/dxss/solve_1d.py
@@ -14,6 +14,8 @@ from dxss.space_time import (
     OrderSpace,
     OrderTime,
     SpaceTime,
+    SpaceTimePETScMatrixWrapper,
+    SpaceTimePETScPreconditionerWrapper,
     ValueAndDerivative,
     get_sparse_matrix,
 )
@@ -116,7 +118,6 @@ ST = SpaceTime(
 )
 ST.setup_spacetime_finite_elements()
 ST.prepare_precondition_gmres()
-A_space_time_linop = ST.get_spacetime_matrix_as_linear_operator()
 b_rhs = ST.get_spacetime_rhs()
 # Prepare the solvers for problems on the slabs
 # GMRes iteration
@@ -142,10 +143,10 @@ def solve_problem(measure_errors=False):
         ST.set_solver_first_slab(
             PySolver(slab_matrix_first_slab_sparse, initial_slab_solver),
         )
-
-        u_sol, res = get_gmres_solution(
-            A_space_time_linop,
-            b_rhs,
+        u_sol, _ = get_gmres_solution(
+            A=SpaceTimePETScMatrixWrapper(ST),
+            b=b_rhs,
+            pre=SpaceTimePETScPreconditionerWrapper(ST),
             maxsteps=100000,
             tol=1e-7,
             printrates=True,
@@ -157,9 +158,10 @@ def solve_problem(measure_errors=False):
         ST.set_solver_first_slab(
             get_lu_solver(ST.msh, ST.get_slab_matrix_first_slab()),
         )  # first slab is special
-        u_sol, res = get_gmres_solution(
-            A_space_time_linop,
-            b_rhs,
+        u_sol, _ = get_gmres_solution(
+            A=SpaceTimePETScMatrixWrapper(ST),
+            b=b_rhs,
+            pre=SpaceTimePETScPreconditionerWrapper(ST),
             maxsteps=100000,
             tol=1e-7,
             printrates=True,

--- a/src/dxss/solve_2d.py
+++ b/src/dxss/solve_2d.py
@@ -13,6 +13,8 @@ from dxss.space_time import (
     OrderSpace,
     OrderTime,
     SpaceTime,
+    SpaceTimePETScMatrixWrapper,
+    SpaceTimePETScPreconditionerWrapper,
     ValueAndDerivative,
     get_sparse_matrix,
 )
@@ -122,7 +124,6 @@ ST = SpaceTime(
 )
 ST.setup_spacetime_finite_elements()
 ST.prepare_precondition_gmres()
-A_space_time_linop = ST.get_spacetime_matrix_as_linear_operator()
 b_rhs = ST.get_spacetime_rhs()
 
 # Prepare the solvers for problems on the slabs
@@ -146,10 +147,10 @@ def solve_problem(measure_errors=False):
             PySolver(slab_matrix_first_slab_sparse, initial_slab_solver),
         )
 
-        u_sol, res = get_gmres_solution(
-            A_space_time_linop,
-            b_rhs,
-            pre=ST.pre_time_marching_improved,
+        u_sol, _ = get_gmres_solution(
+            A=SpaceTimePETScMatrixWrapper(ST),
+            b=b_rhs,
+            pre=SpaceTimePETScPreconditionerWrapper(ST),
             maxsteps=100000,
             tol=1e-7,
             printrates=True,
@@ -159,10 +160,10 @@ def solve_problem(measure_errors=False):
         ST.set_solver_first_slab(
             get_lu_solver(ST.msh, ST.get_slab_matrix_first_slab()),
         )  # first slab is special
-        u_sol, res = get_gmres_solution(
-            A_space_time_linop,
-            b_rhs,
-            pre=ST.pre_time_marching_improved,
+        u_sol, _ = get_gmres_solution(
+            A=SpaceTimePETScMatrixWrapper(ST),
+            b=b_rhs,
+            pre=SpaceTimePETScPreconditionerWrapper(ST),
             maxsteps=100000,
             tol=1e-7,
             printrates=True,

--- a/src/dxss/solve_3d.py
+++ b/src/dxss/solve_3d.py
@@ -15,6 +15,8 @@ from dxss.space_time import (
     OrderTime,
     ProblemParameters,
     SpaceTime,
+    SpaceTimePETScMatrixWrapper,
+    SpaceTimePETScPreconditionerWrapper,
     ValueAndDerivative,
     get_sparse_matrix,
 )
@@ -185,7 +187,6 @@ ST = SpaceTime(
 )
 ST.setup_spacetime_finite_elements()
 ST.prepare_precondition_gmres()
-A_space_time_linop = ST.get_spacetime_matrix_as_linear_operator()
 b_rhs = ST.get_spacetime_rhs()
 
 # Prepare the solvers for problems on the slabs
@@ -210,10 +211,10 @@ def solve_problem(measure_errors=False):
             PySolver(slab_matrix_first_slab_sparse, initial_slab_solver),
         )
 
-        u_sol, res = get_gmres_solution(
-            A_space_time_linop,
-            b_rhs,
-            pre=ST.pre_time_marching_improved,
+        u_sol, _ = get_gmres_solution(
+            A=SpaceTimePETScMatrixWrapper(ST),
+            b=b_rhs,
+            pre=SpaceTimePETScPreconditionerWrapper(ST),
             maxsteps=100000,
             tol=1e-7,
             printrates=True,
@@ -224,10 +225,10 @@ def solve_problem(measure_errors=False):
         ST.set_solver_first_slab(
             get_lu_solver(ST.msh, ST.get_slab_matrix_first_slab()),
         )  # first slab is special
-        u_sol, res = get_gmres_solution(
-            A_space_time_linop,
-            b_rhs,
-            pre=ST.pre_time_marching_improved,
+        u_sol, _ = get_gmres_solution(
+            A=SpaceTimePETScMatrixWrapper(ST),
+            b=b_rhs,
+            pre=SpaceTimePETScPreconditionerWrapper(ST),
             maxsteps=100000,
             tol=1e-7,
             printrates=True,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+"""Pytest configuration and shared fixtures."""  # noqa: INP001
+
+import numpy as np
+import pytest
+
+DEFAULT_SEED = 6357141078224089020
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addoption(
+        "--seed",
+        type=int,
+        nargs="*",
+        default=[DEFAULT_SEED],
+        help="Seed(s) for random number generators in tests",
+    )
+
+
+def pytest_generate_tests(metafunc: pytest.Metafunc) -> None:
+    if "seed" in metafunc.fixturenames:
+        metafunc.parametrize("seed", metafunc.config.getoption("seed"))
+
+
+@pytest.fixture()
+def rng(seed: int) -> np.random.Generator:
+    return np.random.default_rng(seed)

--- a/tests/test_gmres.py
+++ b/tests/test_gmres.py
@@ -1,0 +1,40 @@
+import numpy as np
+import pytest
+from petsc4py import PETSc
+
+from dxss.gmres import get_gmres_solution
+
+
+class IdentityPETScMatrix:
+    def mult(self, _: PETSc.Mat, vec_in: PETSc.Vec, vec_out: PETSc.Vec) -> None:
+        vec_out.array[:] = vec_in.array
+
+
+class IdentityPlusCircularDiffPETScMatrix:
+    def mult(self, _: PETSc.Mat, vec_in: PETSc.Vec, vec_out: PETSc.Vec) -> None:
+        vec_out.array[:] = vec_in.array + (
+            np.roll(vec_in.array, 1) - np.roll(vec_in.array, -1)
+        )
+
+
+class IdentityPETScPreconditioner:
+    def apply(self, _: PETSc.PC, vec_in: PETSc.Vec, vec_out: PETSc.Vec) -> None:
+        vec_out.array[:] = vec_in.array
+
+
+@pytest.mark.parametrize("dimension", [1, 2, 5, 10])
+@pytest.mark.parametrize(
+    "matrix",
+    [IdentityPETScMatrix(), IdentityPlusCircularDiffPETScMatrix()],
+)
+def test_get_gmres_solution(rng, dimension, matrix):
+    """Test GMRes solution `x` for `A @ x = b`."""
+    rhs_vector = PETSc.Vec()
+    rhs_vector.createSeq(dimension)
+    rhs_vector.array[:] = rng.standard_normal(dimension)
+    matrix_mult_solution_vector = PETSc.Vec()
+    matrix_mult_solution_vector.createSeq(dimension)
+    preconditioner = IdentityPETScPreconditioner()
+    (solution_vector, _) = get_gmres_solution(matrix, rhs_vector, preconditioner)
+    matrix.mult(None, solution_vector, matrix_mult_solution_vector)
+    assert np.allclose(matrix_mult_solution_vector, rhs_vector)


### PR DESCRIPTION
Some refactoring to avoid coupling of `get_gmres_solution` function in `dxss.gmres` module to space-time solver class `SpaceTime` implementation, to allow easier unit testing.

Adds basic wrapper classes `SpaceTimePETScMatrixWrapper` and `SpaceTimePETScPreconditionerWrapper` to `dxss.space_time` module which wrap an instance of `SpaceTime` class into the interfaces expected by PETsc to use as respectively a Python [matrix](https://petsc.org/main/petsc4py/petsc_python_types.html#petsc-python-mat) or [preconditioner](https://petsc.org/main/petsc4py/petsc_python_types.html#petsc-python-preconditioner-type).

Also adds a test for refactored `get_gmres_solution` function which checks that returned solution `x` for a system `A @ x = b` satisfies the equation to within numerical precision for a couple of simple test matrices `A` (identity matrix, and matrix corresponding to `A @ x = x + roll(x, 1) - roll(x, -1)` where `roll` does a circular shift operation).

While it's unclear atm if we are going to continue working on `dxss` I started on this to try to tease apart where the numerical errors documented in #53 and also discussed in #66 are arising, in particular if there are issues in how we are interfacing with the PETSc GMRes implementation, with the passing tests here suggesting that `get_gmres_solution` is working as expected.